### PR TITLE
Update ci/* to ignored branches for Version Bump Check

### DIFF
--- a/workflow-templates/minecraft-maven-version-bump.yml
+++ b/workflow-templates/minecraft-maven-version-bump.yml
@@ -7,6 +7,7 @@ name: "Version Bump Check"
 on:
   pull_request:
     branches: [ "main" ]
+    branches-ignore: [ "ci/*" ]
 jobs:
   ensure-version-bump:
     if: ${{ github.base_ref == 'main' || github.base_ref == 'master' }}


### PR DESCRIPTION
Adds `branches-ignore: [ "ci/*" ]` to Version Bump Check so that it does not trigger the version bump check on ci updates.